### PR TITLE
workaround to compile error and MAKEFLAGS from /etc/makepkg.conf

### DIFF
--- a/build
+++ b/build
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -x
 set -e
+source /etc/makepkg.conf
 
 # Basedir configuration
 BASEDIR="$(dirname $0)"
@@ -37,7 +38,6 @@ NCURSES_MD5=8cb9c412e5f2d96bc6f459aa8c6282a1
 
 CONFIG_SUB_SRC=${CONFIG_SUB_SRC:-/usr/share/automake-1.13}
 
-MAKE_OPTS=${MAKE_OPTS:--j12}
 BUILD_GCC=gcc
 BUILD_ARCH=$($BUILD_GCC -v 2>&1 | grep ^Target: | cut -f 2 -d ' ')
 
@@ -121,7 +121,7 @@ if ! [ -e "$NDK_ADDON_PREFIX/lib/libiconv.a" ] ; then
 
     pushd $ICONV_SRC > /dev/null
     ./configure --prefix="$NDK_ADDON_PREFIX" --host=$NDK_TARGET --build=$BUILD_ARCH --with-build-cc=$BUILD_GCC --enable-static --disable-shared
-    make $MAKE_OPTS
+    make $MAKEFLAGS
     make install
     popd > /dev/null
 fi
@@ -131,7 +131,7 @@ if ! [ -e "$NDK_ADDON_PREFIX/lib/libncurses.a" ] ; then
     pushd $NCURSES_SRC > /dev/null
     ./configure --prefix="$NDK_ADDON_PREFIX" --host=$NDK_TARGET --build=$BUILD_ARCH --with-build-cc=$BUILD_GCC --enable-static --disable-shared --includedir="$NDK_ADDON_PREFIX/include" --without-manpages
     echo '#undef HAVE_LOCALE_H' >> "$NCURSES_SRC/include/ncurses_cfg.h"   # TMP hack
-    make $MAKE_OPTS
+    make $MAKEFLAGS
     make install
     popd > /dev/null
 fi
@@ -168,6 +168,6 @@ if ! [ -d "$GHC_DIR" ] ; then
 fi
 
 pushd "$GHC_DIR" > /dev/null
-make $MAKE_OPTS
-make $MAKE_OPTS
+make $MAKEFLAGS
+make $MAKEFLAGS
 popd > /dev/null


### PR DESCRIPTION
As Nathan points out, due to a known bug in ghc, you should run make twice in your script when building ghc. (it'll always fail with `expectJust initTcInteractive` the first time you try to build it fresh)

Additional, since we're already somewhat arch-specific, we should source /etc/makepkg.conf to get the makeflags instead of using just -j6 (on my system I use -j12 for example) I was wondering why my load averages were so low before I realized you set -j manually.
