### PR TITLE
cabal-wrapper configure should use android flags

### DIFF
--- a/patches/cabal-wrapper
+++ b/patches/cabal-wrapper
@@ -6,7 +6,7 @@ export HOME=$NDK
 mkdir -p $NDK/cabal
 [ -e "$NDK/.cabal" ] || ln -s $NDK/cabal $NDK/.cabal
 
-if [ "$1" == "install" ] ; then
+if [ "$1" = "install" ] || [ "$1" = configure ] ; then
     exec /usr/bin/cabal \
         --with-compiler=$BIN_GHC \
         --with-ghc=$BIN_GHC \


### PR DESCRIPTION
Like cabal install, cabal configure accepts all the flags needed to enable
an Android build.

Also, changed == in a test to just =. == is a bashism; = will work in all
POSIX shells.
