### PR TITLE
Make documentation in README clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ a local mirror repo to speed up subsequent ghc clones. To build a
 mirror run:
 
     ./mirror {path to existing ghc clone}
+    
+During ./build the GHC repo is cloned into appropriate path, e.g.:
+
+    ./build-android-14-arm-linux-androideabi-4.7/ghc
+    
+So the mirror path can become this:
+
+    ./mirror build-android-14-arm-linux-androideabi-4.7/ghc
 
 This will build a mirror that will automatically be used by the build
 script to speed up cloning.


### PR DESCRIPTION
I was wondering what would be the location of ghc repo to ./mirror from. After ./build it became clear to here is a patch that includes that information into the docs.
